### PR TITLE
[AB-002] Document public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,21 @@ AutoBuilder
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.jakubkolar/autobuilder/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.jakubkolar/autobuilder)
 
 *AutoBuilder* is a magic builder library for unit tests on JVM.
+
+Current release
+---------------
+
+The most recent version is [0.0.1-alpha](https://github.com/jakubkolar/autobuilder/releases/tag/v0.0.1-alpha),
+released October 30, 2015.
+
+See the [API documentation](http://www.javadoc.io/doc/com.github.jakubkolar/autobuilder/0.0.1-alpha).
+
+To add a dependency on AutoBuilder using Maven, use the following:
+
+```xml
+<dependency>
+    <groupId>com.github.jakubkolar</groupId>
+    <artifactId>autobuilder</artifactId>
+    <version>0.0.1-alpha</version>
+</dependency>
+```

--- a/src/main/java/com/github/jakubkolar/autobuilder/AutoBuilder.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/AutoBuilder.java
@@ -42,7 +42,7 @@ import java.util.Set;
 /**
  * <em>AutoBuilder</em> is a magic builder library for unit tests on JVM.
  *
- * TODO:  ways of resolution: 1) Directly with a resolver or 2) Resolve as a bean with BeanResolver
+ * TODO: AB-003
  *
  */
 @Beta

--- a/src/main/java/com/github/jakubkolar/autobuilder/api/BuilderDSL.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/api/BuilderDSL.java
@@ -29,6 +29,7 @@ import com.github.jakubkolar.autobuilder.spi.ValueResolver;
 import com.google.common.annotations.Beta;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 import java.util.Map;
 
 /**
@@ -135,11 +136,13 @@ import java.util.Map;
  * // ]
  * }</pre>
  *
+ * @param <T> the type of object to be built
  * @author Jakub Kolar
  * @since 0.0.1
  * @see ValueResolver
  */
 @Beta
+@Immutable
 public interface BuilderDSL<T> {
 
     /**

--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderDSLFactory.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderDSLFactory.java
@@ -26,18 +26,24 @@ package com.github.jakubkolar.autobuilder.impl;
 
 import com.github.jakubkolar.autobuilder.api.BuilderDSL;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 /**
- * Instances of {@code BuilderDSL} can be obtained through this factory API.
+ * *** INTERNAL ***
+ *
+ * <p> Instances of {@code BuilderDSL} can be obtained through this factory API.
  */
+@ThreadSafe
 public interface BuilderDSLFactory {
 
     /**
-     * Creates a {@code BuilderDSL}.
+     * *** INTERNAL ***
      *
+     * <p> Creates a {@code BuilderDSL}.
      *
      * @param type class object for the required type
-     * @param <T> type parameter
-     * @return
+     * @param <T> the type of objects the builder will build
+     * @return a brand new instance of {@link BuilderDSL}
      */
     <T> BuilderDSL<T> create(Class<T> type);
 }

--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/Initializable.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/Initializable.java
@@ -24,6 +24,11 @@
 
 package com.github.jakubkolar.autobuilder.impl;
 
+/**
+ * *** INTERNAL ***
+ *
+ * <p> Objects that may be initialized during the {@code AutoBuilder} boot sequence.
+ */
 public interface Initializable {
 
     void init();

--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/ResolversRegistry.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/ResolversRegistry.java
@@ -29,6 +29,13 @@ import com.github.jakubkolar.autobuilder.spi.ValueResolver;
 import javax.annotation.concurrent.ThreadSafe;
 import java.lang.annotation.Annotation;
 
+/**
+ * *** INTERNAL ***
+ *
+ * <p> API for registering global resolvers.
+ *
+ * @see ValueResolver
+ */
 @ThreadSafe
 public interface ResolversRegistry {
 

--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/package-info.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/package-info.java
@@ -23,17 +23,9 @@
  */
 
 /**
- * <a href="https://en.wikipedia.org/wiki/Application_programming_interface">API</a>
- * (excluding SPI) - classes and interfaces meant to be used by clients.
+ * Internal classes and interfaces not meant to be directly used outside of the library.
  *
- * <p> <i>Note on backward compatibility</i>: Because interfaces from this package are
- * meant to be implemented only in the {@code AutoBuilder} library, they are subject to
- * little more <i>relaxed</i> forward compatibility restrictions. More specifically,
- * in future versions these interfaces can:
- * <ul>
- *     <li>introduce new methods</li>
- *     <li>change a type of any method return value to its subtype</li>
- *     <li>change a type of any method parameter to its supertype</li>
- * </ul>
+ * <p> <i>Note on backward compatibility</i>: Contents of this package may change freely
+ * and do not provide any backward compatibility guarantees.
  */
-package com.github.jakubkolar.autobuilder.api;
+package com.github.jakubkolar.autobuilder.impl;

--- a/src/main/java/com/github/jakubkolar/autobuilder/package-info.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/package-info.java
@@ -23,17 +23,6 @@
  */
 
 /**
- * <a href="https://en.wikipedia.org/wiki/Application_programming_interface">API</a>
- * (excluding SPI) - classes and interfaces meant to be used by clients.
- *
- * <p> <i>Note on backward compatibility</i>: Because interfaces from this package are
- * meant to be implemented only in the {@code AutoBuilder} library, they are subject to
- * little more <i>relaxed</i> forward compatibility restrictions. More specifically,
- * in future versions these interfaces can:
- * <ul>
- *     <li>introduce new methods</li>
- *     <li>change a type of any method return value to its subtype</li>
- *     <li>change a type of any method parameter to its supertype</li>
- * </ul>
+ * The root package with the <i>entry point</i> class.
  */
-package com.github.jakubkolar.autobuilder.api;
+package com.github.jakubkolar.autobuilder;

--- a/src/main/java/com/github/jakubkolar/autobuilder/resolvers/BigDecimalResolver.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/resolvers/BigDecimalResolver.java
@@ -35,6 +35,14 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * A special resolver for {@link BigDecimal}, and nothing else.
+ *
+ * <p> TODO AB-013: Support for more types (e.g. BigInteger)
+ *
+ * @author Jakub Kolar
+ * @since 0.0.1
+ */
 @AutoService(ValueResolver.class)
 public class BigDecimalResolver implements ValueResolver {
 

--- a/src/main/java/com/github/jakubkolar/autobuilder/resolvers/GuavaResolver.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/resolvers/GuavaResolver.java
@@ -38,6 +38,22 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Resolver for common types from the <a href="https://github.com/google/guava">Google
+ * Guava</a> library.
+ *
+ * <p> Currently supported types are:
+ * <ul>
+ *     <li><a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Optional.html">Optional</a></li>
+ *     <li><a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/ImmutableCollection.html">ImmutableCollection</a></li>
+ *     <li><a href="http://google.github.io/guava/releases/19.0/api/docs/com/google/common/collect/ImmutableMap.html">ImmutableMap</a></li>
+ * </ul>
+ *
+ * <p> TODO AB-013: Support for more types (e.g. Multiset, Multimap)
+ *
+ * @author Jakub Kolar
+ * @since 0.0.1
+ */
 @AutoService(ValueResolver.class)
 public class GuavaResolver implements ValueResolver {
 
@@ -51,8 +67,7 @@ public class GuavaResolver implements ValueResolver {
         if (ImmutableCollection.class.isAssignableFrom(type)) {
             if (type.isAssignableFrom(ImmutableList.class)) {
                 return type.cast(ImmutableList.of());
-            }
-            else if (type.isAssignableFrom(ImmutableSet.class)) {
+            } else if (type.isAssignableFrom(ImmutableSet.class)) {
                 return type.cast(ImmutableSet.of());
             }
 

--- a/src/main/java/com/github/jakubkolar/autobuilder/resolvers/package-info.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/resolvers/package-info.java
@@ -23,17 +23,12 @@
  */
 
 /**
- * <a href="https://en.wikipedia.org/wiki/Application_programming_interface">API</a>
- * (excluding SPI) - classes and interfaces meant to be used by clients.
+ * Classes that provide extended features to the library.
  *
- * <p> <i>Note on backward compatibility</i>: Because interfaces from this package are
- * meant to be implemented only in the {@code AutoBuilder} library, they are subject to
- * little more <i>relaxed</i> forward compatibility restrictions. More specifically,
- * in future versions these interfaces can:
- * <ul>
- *     <li>introduce new methods</li>
- *     <li>change a type of any method return value to its subtype</li>
- *     <li>change a type of any method parameter to its supertype</li>
- * </ul>
+ * <p> <i>Note on backward compatibility</i>: Contents of this package are intended to be
+ * used only by the library and thus do not provide any backward compatibility guarantees.
+ * Specifically, resolvers from this package may be moved to another project because of
+ * their possible dependencies (e.g. jdk8, guava) that may not be suitable for every
+ * project using {@code AutoBuilder}.
  */
-package com.github.jakubkolar.autobuilder.api;
+package com.github.jakubkolar.autobuilder.resolvers;

--- a/src/main/java/com/github/jakubkolar/autobuilder/spi/ValueResolver.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/spi/ValueResolver.java
@@ -172,10 +172,11 @@ public interface ValueResolver {
      * @param name        the name of the resolved object (meaning depends on the context
      *                    in which the resolution is requested, e.g. it may be a field
      *                    name)
-     * @param annotations additional metadata hints for the resolution (content depends on
-     *                    the resolution context, e.g. it can be annotations found on a
-     *                    field)   @return the resolved instance of type {@code T},
-     *                    including {@code null} as a valid return value
+     * @param annotations additional metadata hints for the resolution (content depends
+     *                    on the resolution context, e.g. it can be annotations found on
+     *                    a field)
+     * @return the resolved instance of type {@code T}, including {@code null} as a valid
+     * return value
      * @throws UnsupportedOperationException if the instance with the given metadata
      *                                       cannot be resolved by this resolver
      */

--- a/src/main/java/com/github/jakubkolar/autobuilder/spi/package-info.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/spi/package-info.java
@@ -23,17 +23,15 @@
  */
 
 /**
- * <a href="https://en.wikipedia.org/wiki/Application_programming_interface">API</a>
- * (excluding SPI) - classes and interfaces meant to be used by clients.
+ * <a href="https://en.wikipedia.org/wiki/Service_provider_interface">SPI</a> (special
+ * kind of API) - interfaces and classes meant to implemented/extended by third parties.
  *
- * <p> <i>Note on backward compatibility</i>: Because interfaces from this package are
- * meant to be implemented only in the {@code AutoBuilder} library, they are subject to
- * little more <i>relaxed</i> forward compatibility restrictions. More specifically,
- * in future versions these interfaces can:
+ * <p> <i>Note on backward compatibility</i>: Interfaces from this package are
+ * meant to be implemented outside of the {@code AutoBuilder} library, and as such they
+ * are subject to <i>strict</i> forward compatibility restrictions. More specifically,
+ * in future versions these interfaces can only:
  * <ul>
- *     <li>introduce new methods</li>
- *     <li>change a type of any method return value to its subtype</li>
- *     <li>change a type of any method parameter to its supertype</li>
+ *     <li>introduce new methods with default implementation</li>
  * </ul>
  */
-package com.github.jakubkolar.autobuilder.api;
+package com.github.jakubkolar.autobuilder.spi;

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>Overview</title>
+</head>
+<body>
+
+<h3><em>AutoBuilder</em> is a magic builder library for writing unit tests on the JVM.</h3>
+
+<p>Main components of the library are:</p>
+<ul>
+    <li>
+        <a href="com/github/jakubkolar/autobuilder/AutoBuilder.html">AutoBuilder.java</a>,
+        the <i>entry point</i> class,
+    </li>
+    <li>
+        <a href="com/github/jakubkolar/autobuilder/api/BuilderDSL.html">BuilderDSL.java</a>,
+        the interface describing the main builder API (for clients using the library),
+    </li>
+    <li>
+        <a href="com/github/jakubkolar/autobuilder/spi/ValueResolver.html">ValueResolver.java</a>,
+        the SPI representing the basic building block of value resolution (for
+        extensions customizing the library).
+    </li>
+</ul>
+
+    <p>For further information see the description of the individual packages.</p>
+
+</body>
+</html>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -24,7 +24,7 @@
     </li>
 </ul>
 
-    <p>For further information see the description of the individual packages.</p>
+<p>For further information see the description of the individual packages.</p>
 
 </body>
 </html>


### PR DESCRIPTION
Javadoc API documentation is now on an acceptable level.
- All packages have a brief package-info.java
- Public API documentation is finished
- README is improved with links and release info
