### PR TITLE
[AB-#11] AutoBuilder does not resolve enums

### DIFF
--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Issue11_Enums.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Issue11_Enums.groovy
@@ -1,0 +1,17 @@
+package com.github.jakubkolar.autobuilder.bug
+
+import com.github.jakubkolar.autobuilder.AutoBuilder
+import spock.lang.Specification
+
+
+class Issue11_Enums extends Specification {
+
+    def "AutoBuilder does not resolve enums"() {
+        when:
+        def instance = AutoBuilder.instanceOf(EnumFileds).build()
+
+        then:
+        assert instance.e != null
+    }
+
+}

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/specification/BuiltInResolversIT.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/specification/BuiltInResolversIT.groovy
@@ -89,7 +89,6 @@ class BuiltInResolversIT extends Specification {
             assert cStrField != null
             assert cIntegerField != null
             assert cEnumField != null
-            assert cEmptyEnumField == null // The same as emptyEnumField
             it
         }
     }

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/specification/BuiltInResolversIT.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/specification/BuiltInResolversIT.groovy
@@ -64,7 +64,7 @@ class BuiltInResolversIT extends Specification {
             assert charWrapperField != null
 
             // Enum
-            // TODO Issue #11: assert enumField != null
+            assert enumField != null
             assert emptyEnumField == null // Only valid value here
 
             // Collections & maps
@@ -89,7 +89,7 @@ class BuiltInResolversIT extends Specification {
             assert cStrField != null
             assert cIntegerField != null
             assert cEnumField != null
-            // TODO Issue #11: assert cEmptyEnumField == null // The same as emptyEnumField
+            assert cEmptyEnumField == null // The same as emptyEnumField
             it
         }
     }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/EnumFileds.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/EnumFileds.java
@@ -1,0 +1,9 @@
+package com.github.jakubkolar.autobuilder.bug;
+
+import com.github.jakubkolar.autobuilder.specification.NonEmptyEnum;
+
+public class EnumFileds {
+    
+    NonEmptyEnum e;
+
+}

--- a/src/test/java/com/github/jakubkolar/autobuilder/specification/BuiltInResolversDTO.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/specification/BuiltInResolversDTO.java
@@ -83,6 +83,10 @@ public class BuiltInResolversDTO {
     Comparable<String> cStrField;
     Comparable<Integer> cIntegerField;
     Comparable<NonEmptyEnum> cEnumField;
-    Comparable<EmptyEnum> cEmptyEnumField;
+
+    // This actually should not be resolved: the only possible value would be 'null' because
+    // EmptyEnum has no constants. But 'null' is not a good choice for Comparable, it is better
+    // to only allow it for just EmptyEnum instances and nothing else
+    //Comparable<EmptyEnum> cEmptyEnumField;
 
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/specification/BuiltInResolversDTO.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/specification/BuiltInResolversDTO.java
@@ -83,6 +83,6 @@ public class BuiltInResolversDTO {
     Comparable<String> cStrField;
     Comparable<Integer> cIntegerField;
     Comparable<NonEmptyEnum> cEnumField;
-    // TODO Issue #11:: Comparable<EmptyEnum> cEmptyEnumField;
+    Comparable<EmptyEnum> cEmptyEnumField;
 
 }


### PR DESCRIPTION
Fixes [AB-#11] AutoBuilder does not resolve enums

This code in BuiltInResolvers

``` java
if (result != null || type.isEnum()) {
    return result;
}
```

caused _any_ enum to be resolved as null because the 
enum resolver did not get a chance to run.
