### PR TITLE
[AB-#9] Cannot specify properties of primitive types

### DIFF
--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Enums_Issue11Test.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Enums_Issue11Test.groovy
@@ -4,11 +4,11 @@ import com.github.jakubkolar.autobuilder.AutoBuilder
 import spock.lang.Specification
 
 
-class Issue11_Enums extends Specification {
+class Enums_Issue11Test extends Specification {
 
     def "AutoBuilder does not resolve enums"() {
         when:
-        def instance = AutoBuilder.instanceOf(EnumFileds).build()
+        def instance = AutoBuilder.instanceOf(EnumFields).build()
 
         then:
         assert instance.e != null

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Primitives_Issue09Test.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Primitives_Issue09Test.groovy
@@ -1,0 +1,43 @@
+package com.github.jakubkolar.autobuilder.bug
+
+import com.github.jakubkolar.autobuilder.AutoBuilder
+import com.github.jakubkolar.autobuilder.specification.ImmutabilityExampleDTO
+import spock.lang.Specification
+
+
+class Primitives_Issue09Test extends Specification {
+
+    def setupSpec() {
+        // Can only be done once per JVM run // TODO: AB-025
+        AutoBuilder.registerValue("PrimitiveFields.globalConfig", 321)
+    }
+
+    def "BuilderDSL.with(String, Object) does not work for properties of primitive types"() {
+        when:
+        def instance = AutoBuilder.instanceOf(PrimitiveFields)
+                .with("i", 123)
+                .build()
+
+        then:
+        assert instance.i == 123
+    }
+
+    def "BuilderDSL.with(Map<String, Object>) does not work for properties of primitive types"() {
+        when:
+        def instance = AutoBuilder.instanceOf(PrimitiveFields)
+                .with(i: 123)
+                .build()
+
+        then:
+        assert instance.i == 123
+    }
+
+    def "AutoBuilder.registerValue does not work for properties of primitive types"() {
+        when:
+        def instance = AutoBuilder.instanceOf(PrimitiveFields).build()
+
+        then:
+        assert instance.globalConfig == 321
+    }
+
+}

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/specification/SpecifyPropertiesIT.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/specification/SpecifyPropertiesIT.groovy
@@ -99,13 +99,13 @@ class SpecifyPropertiesIT extends Specification {
 
             assert strBuilderField.is(sb)
         // Primitives
-            // TODO Issue #9: assert byteField == 0xFF as byte
-            // TODO Issue #9: assert shortField == 0 as short
-            // TODO Issue #9: assert intField == 1
-            // TODO Issue #9: assert longField == 2L
-            // TODO Issue #9: assert floatField == 2.71828f
-            // TODO Issue #9: assert doubleField == 3.14159d
-            // TODO Issue #9: assert charField == 'c' as char
+            assert byteField == 0xFF as byte
+            assert shortField == 0 as short
+            assert intField == 1
+            assert longField == 2L
+            assert floatField == 2.71828f
+            assert doubleField == 3.14159d
+            assert charField == 'c' as char
         // Wrappers
             assert byteWrapperField == 0xFF as Byte
             assert shortWrapperField == 0 as Short

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/EnumFields.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/EnumFields.java
@@ -2,8 +2,8 @@ package com.github.jakubkolar.autobuilder.bug;
 
 import com.github.jakubkolar.autobuilder.specification.NonEmptyEnum;
 
-public class EnumFileds {
-    
+public class EnumFields {
+
     NonEmptyEnum e;
 
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/PrimitiveFields.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/PrimitiveFields.java
@@ -1,0 +1,8 @@
+package com.github.jakubkolar.autobuilder.bug;
+
+public class PrimitiveFields {
+
+    int i;
+    int globalConfig;
+
+}


### PR DESCRIPTION
Fixes #9 

The method `NamedResolver.resolve` did use directly the primitive 
type class (e.g. `int.class`) instead of the corresponding wrapper 
class (e.g. `Integer.class`).
