### PR TITLE
BuilderDSL.with(Map) only considers last property in the map

### DIFF
--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderImpl.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderImpl.java
@@ -89,7 +89,7 @@ class BuilderImpl<T> implements BuilderDSL<T> {
         // TODO: this can be optimized
         BuilderDSL<T> result = this;
         for (Entry<String, Object> prop : properties.entrySet()) {
-            result = with(prop.getKey(), prop.getValue());
+            result = result.with(prop.getKey(), prop.getValue());
         }
         return result;
     }

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Map_Issue07Test.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Map_Issue07Test.groovy
@@ -1,0 +1,30 @@
+package com.github.jakubkolar.autobuilder.bug
+
+import com.github.jakubkolar.autobuilder.AutoBuilder
+import spock.lang.Specification
+
+class Map_Issue07Test extends Specification {
+
+    def "BuilderDSL.with(Map properties) only considers the last property in the map"() {
+        when:
+        def instance = AutoBuilder.instanceOf(SeveralFields)
+                .with(field1: 'ABC', field2: 123, field3: 321)
+                .build()
+
+        then:
+        assert instance.field1 == 'ABC'
+        assert instance.field2 == 123
+        assert instance.field3 == 321
+    }
+
+    def "AutoBuilder.create(Class, Map) only considers the last property in the map"() {
+        when:
+        def instance = AutoBuilder.create(SeveralFields, [field1: 'ABC', field2: 123, field3: 321])
+
+        then:
+        assert instance.field1 == 'ABC'
+        assert instance.field2 == 123
+        assert instance.field3 == 321
+    }
+
+}

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/specification/SpecifyPropertiesIT.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/specification/SpecifyPropertiesIT.groovy
@@ -148,8 +148,8 @@ class SpecifyPropertiesIT extends Specification {
                 .build()
 
         then:
-        // TODO Issue #7: assert instance.strField == 'ABC'
-        // TODO Issue #7: assert instance.intField == 1
+        assert instance.strField == 'ABC'
+        assert instance.intField == 1
         assert instance.primitiveArrayField == ['x', 'y'] as char[]
     }
 
@@ -159,7 +159,7 @@ class SpecifyPropertiesIT extends Specification {
             def instance = BuiltInResolversDTO.class.create(intField: 1, strField: 'ABC')
 
             then:
-            // TODO Issue #7: assert instance.intField == 1
+            assert instance.intField == 1
             assert instance.strField == 'ABC'
         }
     }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/SeveralFields.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/SeveralFields.java
@@ -1,0 +1,9 @@
+package com.github.jakubkolar.autobuilder.bug;
+
+public class SeveralFields {
+
+    String field1;
+    Integer field2;
+    int field3;
+
+}


### PR DESCRIPTION
Fixes #7

The code in `BuilderImpl.with(Map)`

``` java
    result = with(prop.getKey(), prop.getValue());
```

discarded the actual `result` created so far.
