### PR TITLE
[AB-036] API for resolving specific types

### DIFF
--- a/src/main/java/com/github/jakubkolar/autobuilder/api/BuilderDSL.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/api/BuilderDSL.java
@@ -208,6 +208,23 @@ public interface BuilderDSL<T> {
     BuilderDSL<T> with(ValueResolver userResolver);
 
     /**
+     * Uses a given {@code value} when resolving the given {@code type}.
+     *
+     * <p> This method is just a convenience shortcut for adding a {@code ValueResolver}
+     * that resolves the corresponding {@code type}. The resulting builder keeps all the
+     * {@code ValueResolver}s registered with the previous builder (if any), plus this new
+     * {@code ValueResolver}, which takes precedence over the other resolvers and also
+     * over any global or built-in resolvers.
+     *
+     * @param type  the class object for the type to be resolved
+     * @param value the actual value to be used, including {@code null}
+     * @param <R>   the type to be resolved
+     *
+     * @return a new {@code BuilderDSL<T>} with the requested modification(s)
+     */
+    <R> BuilderDSL<T> with(Class<R> type, @Nullable R value);
+
+    /**
      * Builds an instance of {@code T} based on configuration of this builder.
      *
      * <p> The configuration is comprised of all the registered properties, {@code

--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderImpl.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderImpl.java
@@ -103,9 +103,15 @@ class BuilderImpl<T> implements BuilderDSL<T> {
                 factory);
     }
 
+    @Override
+    public <R> BuilderDSL<T> with(Class<R> type, @Nullable R value) {
+        return with(new ExactTypeConstantResolver<>(type, value));
+    }
+
     @Nullable
     @Override
     public T build() {
         return rootResolver.resolve(type, Optional.empty(), type.getSimpleName(), Arrays.asList(type.getAnnotations()));
     }
+
 }

--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/ExactTypeConstantResolver.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/ExactTypeConstantResolver.java
@@ -1,0 +1,45 @@
+package com.github.jakubkolar.autobuilder.impl;
+
+import com.github.jakubkolar.autobuilder.spi.ValueResolver;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+
+class ExactTypeConstantResolver<T> implements ValueResolver {
+
+    private final Class<T> type;
+    @Nullable
+    private final T value;
+
+    public ExactTypeConstantResolver(Class<T> type, @Nullable T value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    @Override
+    public <R> R resolve(Class<R> type, Optional<Type> typeInfo, String name, Collection<Annotation> annotations) {
+        // This is not a "greedy" resolver and resolves just the given type
+        // It would be confusing for the user if they requested e.g. 'AtomicInteger'
+        // to be resolved as 'this.value', and this resolver would resolve e.g. a field
+        // of type 'Number' with a given atomic integer
+        if (Objects.equals(type, this.type)) {
+            return type.cast(value);
+        }
+
+        throw new UnsupportedOperationException(this + " cannot resolve type " + type.getSimpleName());
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("type", type)
+                .append("value", value)
+                .toString();
+    }
+}

--- a/src/main/java/com/github/jakubkolar/autobuilder/spi/ValueResolver.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/spi/ValueResolver.java
@@ -149,7 +149,7 @@ import java.util.Optional;
  * @author Jakub Kolar
  * @see com.github.jakubkolar.autobuilder.api.BuilderDSL#with(ValueResolver)
  * @see com.github.jakubkolar.autobuilder.api.BuilderDSL#with(String, Object)
- * @see com.github.jakubkolar.autobuilder.api.BuilderDSL#with(Map)
+ * @see com.github.jakubkolar.autobuilder.api.BuilderDSL#with(java.util.Map)
  * @see com.github.jakubkolar.autobuilder.AutoBuilder#registerResolver(ValueResolver)
  * @see com.github.jakubkolar.autobuilder.AutoBuilder#registerValue(String, Object, Annotation...)
  * @since 0.0.1

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/specification/ResolveSpecificTypeIT.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/specification/ResolveSpecificTypeIT.groovy
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Jakub Kolar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jakubkolar.autobuilder.specification
+
+import com.github.jakubkolar.autobuilder.AutoBuilder
+import spock.lang.Specification
+
+class ResolveSpecificTypeIT extends Specification {
+
+    def "Resolve the specific type directly"() {
+        given:
+        def desiredValue = new SpecificType(BigDecimal.ONE)
+
+        when:
+        def instance = AutoBuilder.instanceOf(SpecificType)
+                .with(SpecificType, desiredValue)
+                .build()
+
+        then:
+        assert instance.is(desiredValue)
+    }
+
+    def "Specify a desired value for a field of a given type"() {
+        given:
+        def desiredValue = new SpecificType(BigDecimal.ONE)
+
+        when:
+        def instance = AutoBuilder.instanceOf(SpecificTypeDTO)
+                .with(SpecificType, desiredValue)
+                .build()
+
+        then:
+        assert instance.specificTypeField1.is(desiredValue)
+    }
+
+    def "Specified value is used for all fields of a given type"() {
+        given:
+        def desiredValue = new SpecificType(BigDecimal.ONE)
+
+        when:
+        def instance = AutoBuilder.instanceOf(SpecificTypeDTO)
+                .with(SpecificType, desiredValue)
+                .build()
+
+        then:
+        assert instance.specificTypeField1.is(desiredValue)
+        assert instance.specificTypeField2.is(desiredValue)
+    }
+
+    def "Specified value is used for nested fields anywhere in the object graph"() {
+        given:
+        def desiredValue = new SpecificType(BigDecimal.ONE)
+
+        when:
+        def instance = AutoBuilder.instanceOf(NestedSpecificTypeDTO)
+                .with(SpecificType, desiredValue)
+                .build()
+
+        then:
+        assert !instance.notNested.is(desiredValue)
+        assert instance.notNestedSpecific.is(desiredValue)
+        assert instance.nested.specificTypeField1.is(desiredValue)
+        assert instance.nested.specificTypeField2.is(desiredValue)
+    }
+}

--- a/src/test/java/com/github/jakubkolar/autobuilder/specification/NestedSpecificTypeDTO.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/specification/NestedSpecificTypeDTO.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Jakub Kolar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jakubkolar.autobuilder.specification;
+
+public class NestedSpecificTypeDTO {
+    Integer notNested;
+    SpecificType notNestedSpecific;
+    SpecificTypeDTO nested;
+}

--- a/src/test/java/com/github/jakubkolar/autobuilder/specification/SpecificType.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/specification/SpecificType.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Jakub Kolar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jakubkolar.autobuilder.specification;
+
+import java.math.BigDecimal;
+
+public class SpecificType {
+    BigDecimal value;
+
+    public SpecificType(BigDecimal value) {
+        this.value = value;
+    }
+}

--- a/src/test/java/com/github/jakubkolar/autobuilder/specification/SpecificTypeDTO.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/specification/SpecificTypeDTO.java
@@ -24,6 +24,7 @@
 
 package com.github.jakubkolar.autobuilder.specification;
 
-public class ExampleNested {
-    String nestedStrField;
+public class SpecificTypeDTO {
+    SpecificType specificTypeField1;
+    SpecificType specificTypeField2;
 }


### PR DESCRIPTION
Closes AB-036

The API in `BuilderDSL` now includes a convenience method

``` java
 <R> BuilderDSL<T> with(Class<R> type, @Nullable R value);
```

that adds a `ValueResolver` for resolving the specified type.
Specifying a special value globally (e.g. a project-wide config)
should be done by using a global `ValueResolver`, either
with `AutoBuilder.registerResolver` or with a more convenient
and preferred `@AutoService` support for `ServiceLoader`. 
There is then no need to add `AutoBuilder.registerType` method
(`AutoBuilder.register*` methods are harder to use because it 
is not clear when and where to call them actually).
