### PR TITLE
[AB-#8] The supertype of the registered values is not considered

### DIFF
--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Enums_Issue11Test.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Enums_Issue11Test.groovy
@@ -3,7 +3,6 @@ package com.github.jakubkolar.autobuilder.bug
 import com.github.jakubkolar.autobuilder.AutoBuilder
 import spock.lang.Specification
 
-
 class Enums_Issue11Test extends Specification {
 
     def "AutoBuilder does not resolve enums"() {

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Primitives_Issue09Test.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Primitives_Issue09Test.groovy
@@ -4,7 +4,6 @@ import com.github.jakubkolar.autobuilder.AutoBuilder
 import com.github.jakubkolar.autobuilder.specification.ImmutabilityExampleDTO
 import spock.lang.Specification
 
-
 class Primitives_Issue09Test extends Specification {
 
     def setupSpec() {
@@ -27,6 +26,14 @@ class Primitives_Issue09Test extends Specification {
         def instance = AutoBuilder.instanceOf(PrimitiveFields)
                 .with(i: 123)
                 .build()
+
+        then:
+        assert instance.i == 123
+    }
+
+    def "AutoBuilder.create(Class, Map) does not work for properties of primitive types"() {
+        when:
+        def instance = AutoBuilder.create(PrimitiveFields, [i: 123])
 
         then:
         assert instance.i == 123

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Supertypes_Issue08Test.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Supertypes_Issue08Test.groovy
@@ -1,0 +1,149 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Jakub Kolar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.jakubkolar.autobuilder.bug
+
+import com.github.jakubkolar.autobuilder.AutoBuilder
+import spock.lang.Specification
+
+class Supertypes_Issue08Test extends Specification {
+
+    static def myGlobalList = ['ABC', 'DEF'] as LinkedList<String>
+
+    def setupSpec() {
+        // Can only be done once per JVM run // TODO: AB-025
+        AutoBuilder.registerValue("SupertypeFields.globalOField", myGlobalList)
+        AutoBuilder.registerValue("SupertypeFields.globalQField", myGlobalList)
+    }
+
+    def "BuilderDSL.with(String, Object) does not consider the supertype of the passed-in object"() {
+        given:
+        def myList = ['ABC', 'DEF'] as LinkedList<String>
+
+        when:
+        def instance = AutoBuilder.instanceOf(SupertypeFields)
+                .with('abstractListField', myList)
+                .with('abstractCollectionField', myList)
+                .with('objectField', myList)
+                .with('listField', myList)
+                .with('cloneableField', myList)
+                .with('queueField', myList)
+                .with('iterableField', myList)
+                .build()
+
+        then:
+        instance.with {
+            assert abstractListField.is(myList)
+            assert abstractCollectionField.is(myList)
+            assert objectField.is(myList)
+            assert listField.is(myList)
+            assert cloneableField.is(myList)
+            assert queueField.is(myList)
+            assert iterableField.is(myList)
+            it
+        }
+    }
+
+    def "BuilderDSL.with(Map<String, Object>) does not consider the supertypes of the properties"() {
+        given:
+        def myList = ['ABC', 'DEF'] as LinkedList<String>
+
+        when:
+        def instance = AutoBuilder.instanceOf(SupertypeFields)
+            .with(
+                abstractListField: myList,
+                abstractCollectionField: myList,
+                objectField: myList,
+                listField: myList,
+                cloneableField: myList,
+                queueField: myList,
+                iterableField: myList
+            )
+            .build()
+
+        then:
+        instance.with {
+            assert abstractListField.is(myList)
+            assert abstractCollectionField.is(myList)
+            assert objectField.is(myList)
+            assert listField.is(myList)
+            assert cloneableField.is(myList)
+            assert queueField.is(myList)
+            assert iterableField.is(myList)
+            it
+        }
+    }
+
+    def "AutoBuilder.create(Class, Map) does not consider the supertypes of the properties"() {
+        given:
+        def myList = ['ABC', 'DEF'] as LinkedList<String>
+
+        when:
+        def instance = AutoBuilder.create(SupertypeFields, [
+                abstractListField: myList,
+                abstractCollectionField: myList,
+                objectField: myList,
+                listField: myList,
+                cloneableField: myList,
+                queueField: myList,
+                iterableField: myList
+        ])
+
+        then:
+        instance.with {
+            assert abstractListField.is(myList)
+            assert abstractCollectionField.is(myList)
+            assert objectField.is(myList)
+            assert listField.is(myList)
+            assert cloneableField.is(myList)
+            assert queueField.is(myList)
+            assert iterableField.is(myList)
+            it
+        }
+    }
+
+    def "AutoBuilder.registerValue(String, Object) does not consider of the passed-in object"() {
+        given:
+        def myList = null
+
+        when:
+        def instance = AutoBuilder.instanceOf(SupertypeFields)
+                .with('abstractListField', myList)
+                .with('abstractCollectionField', myList)
+                .with('objectField', myList)
+                .with('listField', myList)
+                .with('cloneableField', myList)
+                .with('queueField', myList)
+                .with('iterableField', myList)
+                .build()
+
+        then:
+        instance.with {
+            assert globalOField.is(myGlobalList)
+            assert globalQField.is(myGlobalList)
+            it
+        }
+    }
+
+}

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/specification/SpecifyPropertiesIT.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/specification/SpecifyPropertiesIT.groovy
@@ -95,7 +95,7 @@ class SpecifyPropertiesIT extends Specification {
         instance.with {
         // Strings
             assert strField == 'Str'
-            // TODO: Issue #8: assert charSequenceField == 'ChSeq'
+            assert charSequenceField == 'ChSeq'
 
             assert strBuilderField.is(sb)
         // Primitives
@@ -118,25 +118,24 @@ class SpecifyPropertiesIT extends Specification {
             assert enumField == NonEmptyEnum.CONST1
             assert emptyEnumField == null
         // Collections & maps
-            // TODO: Issue #8: assert collectionField == ['A', 'B']
-            // TODO: Issue #8: assert listField == ['A', 'B']
-            // TODO: Issue #8: assert setField == [1, 2].toSet()
-            // TODO: Issue #8: assert sortedSetField == [1, 2] as TreeSet
-            // TODO: Issue #8: assert mapField == [a: 1, b: 2]
-            // TODO: Issue #8: assert sortedMapField == [a: 1, b: 2] as TreeMap
+            assert collectionField == ['A', 'B']
+            assert listField == ['A', 'B']
+            assert setField == [1, 2].toSet()
+            assert sortedSetField == [1, 2] as TreeSet
+            assert mapField == [a: 1, b: 2]
+            assert sortedMapField == [a: 1, b: 2] as TreeMap
         // Arrays
             assert objArrayField == [1, 'A'] as Object[]
             assert objArrayField2 == ['a', 'b'] as Character[]
             assert primitiveArrayField == ['c', 'd'] as char[]
         // Special
             assert objectField.is(obj)
-            // TODO: Issue #8: assert numberField == BigDecimal.valueOf(999)
-            // TODO: Issue #8: assert serializableField == BigInteger.valueOf(123)
+            assert numberField == BigDecimal.valueOf(999)
+            assert serializableField == BigInteger.valueOf(123)
         // Comparables
-            // TODO: Issue #8: assert cStrField == 'cStr'
-            // TODO: Issue #8: assert cIntegerField == 37
-            // TODO: Issue #8: assert cEnumField == NonEmptyEnum.CONST2
-            // TODO: Issue #11: assert cEmptyEnumField == null
+            assert cStrField == 'cStr'
+            assert cIntegerField == 37
+            assert cEnumField == NonEmptyEnum.CONST2
             it
         }
     }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/SupertypeFields.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/SupertypeFields.java
@@ -1,0 +1,28 @@
+package com.github.jakubkolar.autobuilder.bug;
+
+import java.util.AbstractCollection;
+import java.util.AbstractSequentialList;
+import java.util.List;
+import java.util.Queue;
+
+public class SupertypeFields {
+
+    // Let's use java.util.LinkedList
+
+    // 1. Superclasses (direct & indirect)
+    AbstractSequentialList<?> abstractListField;
+    AbstractCollection<?> abstractCollectionField;
+    Object objectField;
+
+    // 2. Implemented interfaces
+    // a) direct
+    List<?> listField;
+    Cloneable cloneableField;
+    // b) indirect
+    Queue<?> queueField;
+    Iterable<?> iterableField;
+
+    // 3. Global config
+    Object globalOField;
+    Queue<?> globalQField;
+}


### PR DESCRIPTION
Fixes #8

The passed-in value for a given property was only registered
with its direct type. Now it is also registered with all supertypes
(up to `Object`) plus all implemented interfaces and their 
superinterfaces.
