### PR TITLE
[AB-#27] Initialize inherited fields

### DIFF
--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/BeanResolver.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/BeanResolver.java
@@ -35,6 +35,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -76,8 +77,7 @@ class BeanResolver implements ValueResolver {
             Preconditions.checkNotNull(instance);
 
             // Now try to initialize the fields
-            // TODO: inherited fields are skipped now
-            for (Field field : type.getDeclaredFields()) {
+            for (Field field : getAllFields(type)) {
                 // Do not touch static fields
                 if (Modifier.isStatic(field.getModifiers())) {
                     continue;
@@ -100,6 +100,18 @@ class BeanResolver implements ValueResolver {
                     type.toString(), name, annotations.toString(), e.getClass().getSimpleName(), e.getMessage()),
                 e);
         }
+    }
+
+    private static <T> Collection<Field>  getAllFields(Class<T> type) {
+        Collection<Field> result = new ArrayList<>();
+
+        Class<?> currentType = type;
+        while (currentType != null && !currentType.equals(Object.class)) {
+            result.addAll(Arrays.asList(currentType.getDeclaredFields()));
+            currentType = currentType.getSuperclass();
+        }
+
+        return result;
     }
 
     @Nullable

--- a/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Inherited_Issue27Test.groovy
+++ b/src/test/groovy/com/github/jakubkolar/autobuilder/bug/Inherited_Issue27Test.groovy
@@ -22,31 +22,30 @@
  * SOFTWARE.
  */
 
-package com.github.jakubkolar.autobuilder.bug;
+package com.github.jakubkolar.autobuilder.bug
 
-import java.util.AbstractCollection;
-import java.util.AbstractSequentialList;
-import java.util.List;
-import java.util.Queue;
+import com.github.jakubkolar.autobuilder.AutoBuilder
+import spock.lang.Specification
 
-public class SupertypeFields {
+class Inherited_Issue27Test extends Specification {
 
-    // Let's use java.util.LinkedList
+    def "Inherited fields from the direct parent are resolved"() {
+        when:
+        def child = AutoBuilder.instanceOf(Child).build()
 
-    // 1. Superclasses (direct & indirect)
-    AbstractSequentialList<?> abstractListField;
-    AbstractCollection<?> abstractCollectionField;
-    Object objectField;
+        then:
+        assert child.parentField != null
+        assert child.childField != null
+    }
 
-    // 2. Implemented interfaces
-    // a) direct
-    List<?> listField;
-    Cloneable cloneableField;
-    // b) indirect
-    Queue<?> queueField;
-    Iterable<?> iterableField;
+    def "Inherited fields from all parents are resolved"() {
+        when:
+        def grandChild = AutoBuilder.instanceOf(GrandChild).build()
 
-    // 3. Global config
-    Object globalOField;
-    Queue<?> globalQField;
+        then:
+        assert grandChild.parentField != null
+        assert grandChild.childField != null
+        assert grandChild.grandChildField != null
+    }
+
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/Child.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/Child.java
@@ -26,6 +26,6 @@ package com.github.jakubkolar.autobuilder.bug;
 
 public class Child extends Parent {
 
-    String childField;
+    protected String childField;
 
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/Child.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/Child.java
@@ -24,29 +24,8 @@
 
 package com.github.jakubkolar.autobuilder.bug;
 
-import java.util.AbstractCollection;
-import java.util.AbstractSequentialList;
-import java.util.List;
-import java.util.Queue;
+public class Child extends Parent {
 
-public class SupertypeFields {
+    String childField;
 
-    // Let's use java.util.LinkedList
-
-    // 1. Superclasses (direct & indirect)
-    AbstractSequentialList<?> abstractListField;
-    AbstractCollection<?> abstractCollectionField;
-    Object objectField;
-
-    // 2. Implemented interfaces
-    // a) direct
-    List<?> listField;
-    Cloneable cloneableField;
-    // b) indirect
-    Queue<?> queueField;
-    Iterable<?> iterableField;
-
-    // 3. Global config
-    Object globalOField;
-    Queue<?> globalQField;
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/EnumFields.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/EnumFields.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Jakub Kolar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.github.jakubkolar.autobuilder.bug;
 
 import com.github.jakubkolar.autobuilder.specification.NonEmptyEnum;

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/GrandChild.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/GrandChild.java
@@ -24,29 +24,8 @@
 
 package com.github.jakubkolar.autobuilder.bug;
 
-import java.util.AbstractCollection;
-import java.util.AbstractSequentialList;
-import java.util.List;
-import java.util.Queue;
+public class GrandChild extends Child {
 
-public class SupertypeFields {
+    String grandChildField;
 
-    // Let's use java.util.LinkedList
-
-    // 1. Superclasses (direct & indirect)
-    AbstractSequentialList<?> abstractListField;
-    AbstractCollection<?> abstractCollectionField;
-    Object objectField;
-
-    // 2. Implemented interfaces
-    // a) direct
-    List<?> listField;
-    Cloneable cloneableField;
-    // b) indirect
-    Queue<?> queueField;
-    Iterable<?> iterableField;
-
-    // 3. Global config
-    Object globalOField;
-    Queue<?> globalQField;
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/Parent.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/Parent.java
@@ -26,6 +26,6 @@ package com.github.jakubkolar.autobuilder.bug;
 
 public class Parent {
 
-    String parentField;
+    protected String parentField;
 
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/Parent.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/Parent.java
@@ -24,29 +24,8 @@
 
 package com.github.jakubkolar.autobuilder.bug;
 
-import java.util.AbstractCollection;
-import java.util.AbstractSequentialList;
-import java.util.List;
-import java.util.Queue;
+public class Parent {
 
-public class SupertypeFields {
+    String parentField;
 
-    // Let's use java.util.LinkedList
-
-    // 1. Superclasses (direct & indirect)
-    AbstractSequentialList<?> abstractListField;
-    AbstractCollection<?> abstractCollectionField;
-    Object objectField;
-
-    // 2. Implemented interfaces
-    // a) direct
-    List<?> listField;
-    Cloneable cloneableField;
-    // b) indirect
-    Queue<?> queueField;
-    Iterable<?> iterableField;
-
-    // 3. Global config
-    Object globalOField;
-    Queue<?> globalQField;
 }

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/PrimitiveFields.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/PrimitiveFields.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Jakub Kolar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.github.jakubkolar.autobuilder.bug;
 
 public class PrimitiveFields {

--- a/src/test/java/com/github/jakubkolar/autobuilder/bug/SeveralFields.java
+++ b/src/test/java/com/github/jakubkolar/autobuilder/bug/SeveralFields.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Jakub Kolar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.github.jakubkolar.autobuilder.bug;
 
 public class SeveralFields {


### PR DESCRIPTION
Fixes #27

The `BeanResolver` used `type.getDeclaredFields()`, and that, also according to javadoc, excludes the inherited fields. The code was fixed to investigate and collect all fields in the class hierarchy up to `Object`.
