### PR TITLE
[AB-047] Value resolver should get a resolution context

### DIFF
--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderImpl.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/BuilderImpl.java
@@ -28,10 +28,8 @@ import com.github.jakubkolar.autobuilder.api.BuilderDSL;
 import com.github.jakubkolar.autobuilder.spi.ValueResolver;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 
 class BuilderImpl<T> implements BuilderDSL<T> {
 
@@ -111,7 +109,8 @@ class BuilderImpl<T> implements BuilderDSL<T> {
     @Nullable
     @Override
     public T build() {
-        return rootResolver.resolve(type, Optional.empty(), type.getSimpleName(), Arrays.asList(type.getAnnotations()));
+        VRContext<T> context = VRContext.createRoot(rootResolver, type);
+        return context.resolve();
     }
 
 }

--- a/src/main/java/com/github/jakubkolar/autobuilder/impl/VRContext.java
+++ b/src/main/java/com/github/jakubkolar/autobuilder/impl/VRContext.java
@@ -1,0 +1,135 @@
+package com.github.jakubkolar.autobuilder.impl;
+
+import com.github.jakubkolar.autobuilder.spi.ValueResolver;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+
+class VRContext<T> implements ValueResolver.Context<T> {
+
+    private final ValueResolver resolver;
+    private final VRContext<?> parent;
+    private final String name;
+    private final Class<T> type;
+    private final Optional<Type> typeInfo;
+    private final ImmutableCollection<Annotation> annotations;
+
+    private T result = null;
+    private Optional<Exception> error = Optional.empty();
+    private boolean resolved = false;
+
+    public static <T> VRContext<T> createRoot(ValueResolver rootResolver, Class<T> type) {
+        return new VRContext<>(
+                rootResolver,
+                null,
+                type.getSimpleName(),
+                type,
+                Optional.empty(),
+                ImmutableList.of()
+        );
+    }
+
+    public VRContext<?> createChild(Field field) {
+        return new VRContext<>(
+                resolver,
+                this,
+                field.getName(),
+                field.getType(),
+                Optional.of(field.getGenericType()),
+                ImmutableList.copyOf(field.getAnnotations())
+        );
+    }
+
+    private VRContext(ValueResolver resolver, VRContext<?> parent, String name, Class<T> type, Optional<Type> typeInfo, ImmutableCollection<Annotation> annotations) {
+        this.resolver = resolver;
+        this.parent = parent;
+        this.name = name;
+        this.type = type;
+        this.typeInfo = typeInfo;
+        this.annotations = annotations;
+    }
+
+    public ValueResolver getResolver() {
+        return resolver;
+    }
+
+    @Override
+    public ValueResolver getRootResolver() {
+        return getParent().map(p -> p.getRootResolver()).orElse(resolver);
+    }
+
+    @Override
+    public Optional<ValueResolver.Context<?>> getParent() {
+        return Optional.ofNullable(parent);
+    }
+
+    @Override
+    public String getName() {
+        return parent == null ? name : parent.getName() + '.' + name;
+    }
+
+    @Override
+    public Class<T> getType() {
+        return type;
+    }
+
+    @Override
+    public Optional<Type> getTypeInfo() {
+        return typeInfo;
+    }
+
+    @Override
+    public Collection<Annotation> getAnnotations() {
+        return annotations;
+    }
+
+    @Override
+    public T getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Object result) {
+        this.result = type.cast(result);
+    }
+
+    @Override
+    public Optional<Exception> getError() {
+        return error;
+    }
+
+    @Override
+    public void setResolved() {
+        this.resolved = true;
+    }
+
+    @Override
+    public void setFailed(Exception e) {
+        this.error = Optional.of(e);
+    }
+
+    public T resolve() {
+        if (resolved) {
+            return result;
+        }
+
+        // Resolve is not supposed to throw under normal circumstances
+        resolver.resolve(this);
+
+        if (!resolved) {
+            // TODO: consider custom (unchecked) exception?
+            throw new UnsupportedOperationException("Could not resolve type "
+                // TODO: use toString here to be more descriptive
+                + type.getSimpleName(), getError().orElse(null));
+        }
+
+        return result;
+    }
+
+    // TODO: toString for debugging?
+}

--- a/src/main/java/com/github/jakubkolar/autobuilder/spi/design.puml
+++ b/src/main/java/com/github/jakubkolar/autobuilder/spi/design.puml
@@ -1,0 +1,56 @@
+@startuml
+
+interface ValueResolver {
+    +<T> resolve(type, typeInfo, name, annotations): T
+}
+
+class VRContext<T> {
+    builder: BuilderDSL<T>
+    parent: VRContext [opt]
+
+    .. Input ..
+    name: String
+    type: Class<T>
+    typeInfo: Type
+    annotations: Collection
+
+    .. Output ..
+    result: T
+    state: ??
+    errors: ??
+
+}
+
+enum Outcome {
+    NO_RESULT
+    FAILURE
+    RESOLVED
+}
+
+@enduml
+
+@startuml
+
+Not_Resolved: No result yet
+Partially_Resolved: Result exists,
+Partially_Resolved: but incomplete
+Fully_Resolved: Result complete,
+Fully_Resolved: resolution successful
+Failed: Error(s) during resolution
+Failed: cannot proceed
+
+[*] --> Not_Resolved
+
+Not_Resolved --> Partially_Resolved
+Not_Resolved --> Failed
+Not_Resolved --> Fully_Resolved
+Partially_Resolved -> Partially_Resolved
+Partially_Resolved --> Fully_Resolved
+Partially_Resolved --> Failed
+
+Fully_Resolved --> Failed
+Fully_Resolved --> [*]
+Failed --> [*]
+
+
+@enduml


### PR DESCRIPTION
Like: 
- what is the root type that is being resolved? 
- what is the parent type? what is the current path?

- [x] ~~Design the interface for the context~~
  - abandoned idea: Lifecycle on the context objects, various states (Not_Resolved, Partially_Resolved)
    - would allow for enrichment or validation
    - too complicated, unnecessary complexity, little value

- [ ] Change `BuilderImpl` to actually use the context
  - move most of the resolution to `VRContext` implementation class
    - resolve method
    - error detection
  - reuse stuff from `VRContext` when creating fields in BeanResolver

- [ ] Enhance existing tests
- [ ] Document the interface with proper Javadoc
- [ ] Change existing resolvers to use the context
  - Still keep the old method as deprecated
